### PR TITLE
Add link to CG report in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Proposals for HTTPS for Local Servers
 
 This repository collects proposals on HTTPS for local servers by any participants in HTTPS in Local Network Community Group.
+
+Proposed technical approaches are sorted out and published as a Community Group
+Report, [Approaches to Achieving HTTPS in Local Network](https://httpslocal.github.io/proposals).
+
 Before submitting a Pull Request, every contributor should note that any proposal should be derived from [Use Cases](https://github.com/httpslocal/usecases/blob/master/UseCases.md) and must satisfy [Requirements](https://github.com/httpslocal/usecases/blob/master/Requirements.md). Of course, any proposals are welcome!
 
 - If you cannot find a use case that you assume in [Use Cases](https://github.com/httpslocal/usecases/blob/master/UseCases.md), you can feel free to propose an additional one in [the GitHub issue on use cases](https://github.com/httpslocal/usecases/issues/1). This issue is always open to explore further ideas.


### PR DESCRIPTION
README does not have a link to a CG report, [Approaches to Achieving HTTPS in Local Network](https://httpslocal.github.io/proposals).